### PR TITLE
fix: hide input when entering secure values

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -1,3 +1,4 @@
+import { Writable } from 'stream'
 import { readFileSync } from 'fs'
 import readline from 'readline'
 
@@ -33,13 +34,18 @@ export const readSecureValue = (question: string, name: string, required = true)
 
       // try interactive prompt
       if (!process.stdout.isTTY) return reject(new Error(`${name} required`))
-      const rl = readline.createInterface(process.stdin, process.stdout)
+      const invisible = new Writable({
+        write: (_chunk, _encoding, callback) => callback()
+      })
+      const rl = readline.createInterface(process.stdin, invisible, undefined, true)
       let valueAnswer = ''
       rl.on('close', () => {
+        process.stdout.write('\n')
         if (required && valueAnswer.length === 0) return reject(new Error(`${name} required`))
         return resolve(valueAnswer)
       })
-      rl.question(question, answer => {
+      process.stdout.write(question)
+      rl.question('', answer => {
         valueAnswer = answer
         rl.close()
       })


### PR DESCRIPTION
Documentary PR. Basically, what I was trying to accomplish is invisible input;

```
Please enter your password: [and anything you type here just doesn't show, at all]
```

I did a bunch of research, and [this discussion](https://stackoverflow.com/questions/24037545/how-to-hide-password-in-the-nodejs-console) offers a whole bunch of different approaches, but I believe what I've implemented here is simpler by far. (Perhaps slightly less portable, but that isn't a requirement.)

Closes #2 