### PR TITLE
feat: migrate to docker build workflow

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:14
+
+ARG targetNode=node14
+
+RUN npm i -g pkg pkg-fetch
+
+ENV BUILD_TARGET=alpine-x64
+
+WORKDIR /build
+
+COPY package.json package-lock.json tsconfig.json /build
+
+RUN npm i
+
+RUN echo 'npm run build:src &&\\' > /usr/local/bin/build-cli
+RUN echo "pkg out/src/main.js -t ${targetNode}-\${BUILD_TARGET} --output /build/bin/edge" >> /usr/local/bin/build-cli
+
+RUN chmod +x /usr/local/bin/build-cli
+
+CMD ["build-cli"]

--- a/.build/auto_target.sh
+++ b/.build/auto_target.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ "${BUILD_TARGET}" != "" ]; then
+  echo -n ${BUILD_TARGET}
+  exit
+elif [ "$(which sw_vers)" != "" ]; then
+  echo -n macos-x64
+  exit
+fi

--- a/.build/build.sh
+++ b/.build/build.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+set -e
+
+[ "${BUILD_TARGET}" = "" ] && echo "BUILD_TARGET required" && exit 1
+
+[ "${ROOT}" = "" ] && ROOT=${PWD}
+
+BUILD_IMAGE_NAME=registry.edge.network/edge/cli-build:${BUILD_TARGET}
+
+docker build ${ROOT} \
+  -f .build/Dockerfile \
+  -t ${BUILD_IMAGE_NAME}
+
+[ "${PKG_CACHE_PATH}" = "" ] && PKG_CACHE_PATH=${HOME}/.pkg-cache
+
+docker run --rm -ti \
+  -v ${PKG_CACHE_PATH}:/root/.pkg-cache \
+  -v ${ROOT}/bin:/build/bin \
+  -v ${ROOT}/src:/build/src:ro \
+  -e BUILD_TARGET=${BUILD_TARGET} \
+  ${BUILD_IMAGE_NAME}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.build/
+.eslint*
+.github/
+.gitignore
+*.md
+bin/
+node_modules/
+out/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@
 
 Command line interface for the Edge network
 
+## Development
+
+The simplest way to test this application on your development machine is to execute `npm run dev -- [your input]` which uses [ts-node](https://www.npmjs.com/package/ts-node) to automatically transpile code without writing output.
+
+If you want to build and run source, for example if there is a problem with ts-node or you just want to compare results, you can execute `npm run build:src && npm run dev:from-src`
+
+## Build
+
+We use [pkg](https://www.npmjs.com/package/pkg) to build distributable binaries.
+
+The recommended approach to build a CLI binary is using the Docker workflow. Start Docker, then execute `npm run build` and wait. When the process has completed, you should see a `bin/edge` file that you can execute directly on your host.
+
+If you are unable to use the Docker build workflow, you can try building on host. You will need to install the `optionalDependencies` from package.json. Then, execute `npm run build:src && npm run build:executable` and wait; you should soon see a `bin/edge` file created that you can execute directly.
+
+<!--
+### CI Build
+
+This section is TODO
+-->
+
 ## License
 
 Edge is the infrastructure of Web3. A peer-to-peer network and blockchain providing high performance decentralised web services, powered by the spare capacity all around us.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@edge/index-utils": "^0.1.0",
         "@edge/xe-utils": "^0.1.2",
         "commander": "^8.1.0",
-        "dockerode": "^3.3.1"
+        "dockerode": "^3.3.1",
+        "pkg": "*"
       },
       "devDependencies": {
         "@edge/eslint-config-typescript": "^0.1.0",
@@ -24,6 +25,9 @@
         "pkg": "^5.3.1",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.2"
+      },
+      "optionalDependencies": {
+        "pkg": "^5.3.3"
       }
     },
     "../wallet-utils": {
@@ -2367,10 +2371,13 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
       "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -2511,9 +2518,9 @@
       }
     },
     "node_modules/pkg": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.1.tgz",
-      "integrity": "sha512-jT/sptM1ZG++FNk+jnJYNoWLDQXYd7hqpnBhd5j18SNW1jJzNYo55RahuCiD0KN0PX9mb53GWCqKM0ia/mJytA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.3.tgz",
+      "integrity": "sha512-48qPxwyPvKfUuXxeK+kS3mBvfWWTX2khAdceDThbWCc8OUz3RFyO1Ft8SVkq2gQfPU2DtiPtWaf2SKH0Dlx59g==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "7.13.13",
@@ -2525,7 +2532,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.2",
+        "pkg-fetch": "3.2.3",
         "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -2545,9 +2552,9 @@
       }
     },
     "node_modules/pkg-fetch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.2.tgz",
-      "integrity": "sha512-bLhFNT4cNnONxzbHo1H2mCCKuQkCR4dgQtv0gUZnWtp8TDP0v0UAXKHG7DXhAoTC5IYP3slLsFJtIda9ksny8g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.3.tgz",
+      "integrity": "sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -3166,6 +3173,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "node_modules/ts-node": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
@@ -3331,6 +3344,22 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5241,10 +5270,13 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -5349,9 +5381,9 @@
       "dev": true
     },
     "pkg": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.1.tgz",
-      "integrity": "sha512-jT/sptM1ZG++FNk+jnJYNoWLDQXYd7hqpnBhd5j18SNW1jJzNYo55RahuCiD0KN0PX9mb53GWCqKM0ia/mJytA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.3.tgz",
+      "integrity": "sha512-48qPxwyPvKfUuXxeK+kS3mBvfWWTX2khAdceDThbWCc8OUz3RFyO1Ft8SVkq2gQfPU2DtiPtWaf2SKH0Dlx59g==",
       "dev": true,
       "requires": {
         "@babel/parser": "7.13.13",
@@ -5363,7 +5395,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.2",
+        "pkg-fetch": "3.2.3",
         "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -5372,9 +5404,9 @@
       }
     },
     "pkg-fetch": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.2.tgz",
-      "integrity": "sha512-bLhFNT4cNnONxzbHo1H2mCCKuQkCR4dgQtv0gUZnWtp8TDP0v0UAXKHG7DXhAoTC5IYP3slLsFJtIda9ksny8g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.3.tgz",
+      "integrity": "sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -5832,6 +5864,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "ts-node": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
@@ -5943,6 +5981,22 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
-    "build": "npm run build:src && npm run build:executable",
+    "build": "ROOT=${PWD} BUILD_TARGET=$(.build/auto_target.sh) .build/build.sh",
+    "build:on-host": "npm run build:src && npm run build:executable",
     "build:src": "tsc",
     "build:executable": "pkg out/src/main.js -t host --output bin/edge",
     "dev": "ts-node src/main.ts",
@@ -25,7 +26,6 @@
     "@typescript-eslint/eslint-plugin": "^4.29.3",
     "@typescript-eslint/parser": "^4.29.3",
     "eslint": "^7.32.0",
-    "pkg": "^5.3.1",
     "ts-node": "^10.2.1",
     "typescript": "^4.4.2"
   },
@@ -34,5 +34,8 @@
     "@edge/xe-utils": "^0.1.2",
     "commander": "^8.1.0",
     "dockerode": "^3.3.1"
+  },
+  "optionalDependencies": {
+    "pkg": "^5.3.3"
   }
 }


### PR DESCRIPTION
This is a documentary PR just to record a resolution (or rather, workaround!)

As discussed at length on Discord and in https://github.com/edge/cli/issues/29#issuecomment-942322813 I have had problems with local binaries since adding the `dockerode` package to CLI. The actual build was OK, but then I would get this error and immediate failure every time I executed the `edge` binary:

```
Anny@Aneurins-iMac cli % ./bin/edge                     
dyld: lazy symbol binding failed: Symbol not found: _node_module_register
  Referenced from: /var/folders/0g/xb1vnhb10ns05p_728cspkm80000gn/T/145269e930e3f95c254d50ae2988fc26573d7a68337d75c1ec5a1a9adacecc28/sshcrypto.node
  Expected in: flat namespace

dyld: Symbol not found: _node_module_register
  Referenced from: /var/folders/0g/xb1vnhb10ns05p_728cspkm80000gn/T/145269e930e3f95c254d50ae2988fc26573d7a68337d75c1ec5a1a9adacecc28/sshcrypto.node
  Expected in: flat namespace

zsh: abort      ./bin/edge
```

After spending the best part of a day trying to diagnose and fix this, we (@adamkdean and I) at least ascertained it's an environmental problem and the build is basically sane; so, I've migrated the build workflow into a Docker-based process. The image is semi-static so it rebuilds quickly if there are no changes to package.json. Some parts of this are a bit primitive, such as the `auto_target.sh` host selection, but it's separated out so that it's easy to patch up later.

For now, I am able to build for my Mac OS host and test the build, which meets my present requirements:

```
Anny@Aneurins-iMac cli % npm run build

> @edge/cli@1.0.0 build
> ROOT=${PWD} BUILD_TARGET=$(.build/auto_target.sh) .build/build.sh

[+] Building 0.1s (13/13) FINISHED                                                      
 => [internal] load build definition from Dockerfile                               0.0s
 => => transferring dockerfile: 37B                                                0.0s
 => [internal] load .dockerignore                                                  0.0s
 => => transferring context: 34B                                                   0.0s
 => [internal] load metadata for docker.io/library/node:14                         0.0s
 => [1/8] FROM docker.io/library/node:14                                           0.0s
 => [internal] load build context                                                  0.0s
 => => transferring context: 105B                                                  0.0s
 => CACHED [2/8] RUN npm i -g pkg pkg-fetch                                        0.0s
 => CACHED [3/8] WORKDIR /build                                                    0.0s
 => CACHED [4/8] COPY package.json package-lock.json tsconfig.json /build          0.0s
 => CACHED [5/8] RUN npm i                                                         0.0s
 => CACHED [6/8] RUN echo 'npm run build:src &&\\' > /usr/local/bin/build-cli      0.0s
 => CACHED [7/8] RUN echo "pkg out/src/main.js -t node14-${BUILD_TARGET} --output  0.0s
 => CACHED [8/8] RUN chmod +x /usr/local/bin/build-cli                             0.0s
 => exporting to image                                                             0.0s
 => => exporting layers                                                            0.0s
 => => writing image sha256:110be13749a6f6937beb0655cefa7b3e35f9c105f67b9c56ec372  0.0s
 => => naming to registry.edge.network/edge/cli-build:macos-x64                    0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

> @edge/cli@1.0.0 build:src /build
> tsc

> pkg@5.3.3
prebuild-install WARN install No prebuilt binaries found (target=v14.17.6 runtime=node arch=x64 libc= platform=darwin)
Anny@Aneurins-iMac cli % ./bin/edge 
Usage: edge [options] [command]

Options:
  -n, --network <name>  network to use (default: "test")
  -v, --verbose         enable verbose logging (default: false)
  -w, --wallet <file>   wallet file path
  -h, --help            display help for command

Commands:
  device                manage device
  stake                 manage stakes
  transaction|tx        manage transactions
  wallet                manage wallet
  help [command]        display help for command
```