### PR TITLE
Stake index integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@edge/index-utils": "^0.1.0",
+        "@edge/index-utils": "^0.3.1",
         "@edge/wallet-utils": "^0.14.2",
         "@edge/xe-utils": "^1.0.4",
         "chalk": "^4.1.2",
@@ -181,8 +181,9 @@
       }
     },
     "node_modules/@edge/index-utils": {
-      "version": "0.1.0",
-      "integrity": "sha512-TcwTNyNwdV2ezZAmFnwLn8B8zmTKtngS6zHlaqmfOQ+BFyKM+YWubwONQKa1QctIUHlL31epZB8S8AGOK+EObQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.3.1.tgz",
+      "integrity": "sha512-SqOYaNtnvxUtx7uKxtzt2T3vc9RTBlFUOJpGvD8Ujr60RgkCmtOe5NxryoHC12fSLfBvGGISb3rykG8M3791qg==",
       "dependencies": {
         "superagent": "^6.1.0"
       }
@@ -3311,8 +3312,9 @@
       "requires": {}
     },
     "@edge/index-utils": {
-      "version": "0.1.0",
-      "integrity": "sha512-TcwTNyNwdV2ezZAmFnwLn8B8zmTKtngS6zHlaqmfOQ+BFyKM+YWubwONQKa1QctIUHlL31epZB8S8AGOK+EObQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.3.1.tgz",
+      "integrity": "sha512-SqOYaNtnvxUtx7uKxtzt2T3vc9RTBlFUOJpGvD8Ujr60RgkCmtOe5NxryoHC12fSLfBvGGISb3rykG8M3791qg==",
       "requires": {
         "superagent": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "@edge/index-utils": "^0.1.0",
+    "@edge/index-utils": "^0.3.1",
     "@edge/wallet-utils": "^0.14.2",
     "@edge/xe-utils": "^1.0.4",
     "chalk": "^4.1.2",

--- a/src/device/cli.ts
+++ b/src/device/cli.ts
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE.md file. All rights reserved.
 
 import * as data from './data'
+import * as index from '@edge/index-utils'
 import * as node from './node'
 import * as walletCLI from '../wallet/cli'
 import * as xe from '@edge/xe-utils'
@@ -54,7 +55,7 @@ const addAction = (parent: Command, addCmd: Command, network: Network) => async 
   })()
 
   // get user stakes, check whether device already assigned
-  const stakes = await xe.stake.stakes(network.blockchain.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address(), { limit: 999 })
   if (Object.keys(stakes).length === 0) throw new Error('no stakes')
   const assigned = Object.values(stakes).find(s => s.device === device.address)
   if (assigned !== undefined) {

--- a/src/stake/cli.ts
+++ b/src/stake/cli.ts
@@ -157,7 +157,7 @@ const listAction = (parent: Command, listCmd: Command, network: Network) => asyn
   const printID = printTrunc(!opts.fullIds, 8)
 
   const storage = withFile(opts.wallet)
-  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address(), { limit: 999 })
 
   if (opts.json) {
     console.log(JSON.stringify(stakes, undefined, 2))
@@ -211,7 +211,7 @@ const releaseAction = (parent: Command, releaseCmd: Command, network: Network) =
     })()
   }
   const storage = withFile(opts.wallet)
-  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address(), { limit: 999 })
   const stake = findOne(stakes, id)
 
   if (stake.released !== undefined) {
@@ -304,7 +304,7 @@ const unlockAction = (parent: Command, unlockCmd: Command, network: Network) => 
     })()
   }
   const storage = withFile(opts.wallet)
-  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address(), { limit: 999 })
   const stake = findOne(stakes, id)
 
   if (stake.unlockRequested !== undefined) {

--- a/src/stake/cli.ts
+++ b/src/stake/cli.ts
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 
+import * as index from '@edge/index-utils'
 import * as walletCLI from '../wallet/cli'
 import * as xe from '@edge/xe-utils'
 import { Command } from 'commander'
@@ -156,7 +157,7 @@ const listAction = (parent: Command, listCmd: Command, network: Network) => asyn
   const printID = printTrunc(!opts.fullIds, 8)
 
   const storage = withFile(opts.wallet)
-  const stakes = await xe.stake.stakes(network.blockchain.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
 
   if (opts.json) {
     console.log(JSON.stringify(stakes, undefined, 2))
@@ -210,7 +211,7 @@ const releaseAction = (parent: Command, releaseCmd: Command, network: Network) =
     })()
   }
   const storage = withFile(opts.wallet)
-  const stakes = await xe.stake.stakes(network.blockchain.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
   const stake = findOne(stakes, id)
 
   if (stake.released !== undefined) {
@@ -303,7 +304,7 @@ const unlockAction = (parent: Command, unlockCmd: Command, network: Network) => 
     })()
   }
   const storage = withFile(opts.wallet)
-  const stakes = await xe.stake.stakes(network.blockchain.baseURL, await storage.address())
+  const { results: stakes } = await index.stake.stakes(network.index.baseURL, await storage.address())
   const stake = findOne(stakes, id)
 
   if (stake.unlockRequested !== undefined) {

--- a/src/stake/index.ts
+++ b/src/stake/index.ts
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 
-import * as xe from '@edge/xe-utils'
+import * as index from '@edge/index-utils'
 import { namedError } from '../helpers'
 
 export const ambiguousIDError = namedError('AmbiguousIDError')
 
-export const findOne = (stakes: xe.stake.Stakes, id: string): xe.stake.Stake => {
+export const findOne = (stakes: index.stake.AddressedStake[], id: string): index.stake.AddressedStake => {
   if (id.length < 3) throw new Error('stake ID must be at least 3 characters')
   const ss = Object.values(stakes).filter(s => s.id.slice(0, id.length) === id)
   if (ss.length === 0) throw new Error(`stake ${id} not found`)

--- a/src/transaction/cli.ts
+++ b/src/transaction/cli.ts
@@ -15,7 +15,7 @@ import { Command, Option } from 'commander'
 import { askToSignTx, handleCreateTxResult, withNetwork as indexWithNetwork } from './index'
 import { formatXE, parseAmount, withNetwork as xeWithNetwork } from './xe'
 
-const formatIndexTx = (address: string, tx: index.Tx): string => {
+const formatIndexTx = (address: string, tx: index.tx.Tx): string => {
   const data: Record<string, string> = {
     Tx: tx.hash,
     Nonce: tx.nonce.toString(),

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -42,6 +42,6 @@ export const handleCreateTxResult = (network: Network, result: xe.tx.CreateRespo
 export const withNetwork = (network: Network) => {
   const host = network.index.baseURL
   return {
-    transactions: (address: string, params?: index.TxsParams) => index.transactions(host, address, params)
+    transactions: (address: string, params?: index.tx.TxsParams) => index.tx.transactions(host, address, params)
   }
 }


### PR DESCRIPTION
These changes change the primary source for stake data to index, rather than blockchain. At the moment, this doesn't offer significant benefits, primarily because CLI's partial matching requirements prevent us from just using `/stake/:id` API, but I've already scoped a `stake history` function off-branch and we are better positioned to add more capabilities in future.

Note: we will probably want to review the uses of `{ limit: 999 }` before it becomes a problem. I'll create an issue shortly to this effect to recommend a more robust mechanism for querying all.