### PR TITLE
feat: add network flags

### DIFF
--- a/src/main-mainnet.ts
+++ b/src/main-mainnet.ts
@@ -20,6 +20,7 @@ main(process.argv, {
     latestChecksumURL: (os, arch) => `https://files.edge.network/cli/mainnet/${os}/${arch}/latest/checksum`,
     latestVersionURL: (os, arch) => `https://files.edge.network/cli/mainnet/${os}/${arch}/latest/version`
   },
+  flags: {},
   index: {
     baseURL: 'https://index.xe.network'
   },

--- a/src/main-testnet.ts
+++ b/src/main-testnet.ts
@@ -20,6 +20,9 @@ main(process.argv, {
     latestChecksumURL: (os, arch) => `https://files.edge.network/cli/testnet/${os}/${arch}/latest/checksum`,
     latestVersionURL: (os, arch) => `https://files.edge.network/cli/testnet/${os}/${arch}/latest/version`
   },
+  flags: {
+    onboarding: true
+  },
   index: {
     baseURL: 'https://index.test.network'
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ export type Network = {
     latestChecksumURL: (os: string, arch: string) => string
     latestVersionURL: (os: string, arch: string) => string
   }
+  flags: Record<string, boolean>
   index: {
     baseURL: string
   }
@@ -36,7 +37,7 @@ export type Network = {
 
 const main = (argv: string[], network: Network): void => {
   const cli = createCLI(network)
-  deviceCLI.withProgram(cli, network)
+  if (network.flags.onboarding) deviceCLI.withProgram(cli, network)
   stakeCLI.withProgram(cli, network)
   transactionCLI.withProgram(cli, network)
   updateCLI.withProgram(cli, network, argv)


### PR DESCRIPTION
also disable onboarding for mainnet at this juncture, allowing other fixes/features to be deployed