### PR TITLE
Community command

### DIFF
--- a/src/about/cli.ts
+++ b/src/about/cli.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander'
+
+const communityAction = () => async () => {
+  console.log([
+    '\n',
+    'Browse public Edge code on GitHub:\n',
+    '  https://github.com/edge\n\n',
+    'Chat with the community on Telegram, Discord, or Reddit:\n',
+    '  https://t.me/edgenetwork\n',
+    '  https://discord.gg/3sEvuYJ\n',
+    '  https://reddit.com/r/edgenetwork\n\n',
+    'Follow Edge on Twitter or Facebook:\n',
+    '  https://twitter.com/edgenetwork\n',
+    '  https://www.facebook.com/edgenetworktech\n\n',
+    'Keep up with Edge on Medium or sign up to the mailing list:\n',
+    '  https://medium.com/dadi\n',
+    '  https://edge.network/en/'
+  ].join(''))
+}
+
+export const commands = (): Command[] => {
+  const community = new Command('community')
+    .description('show community links')
+    .action(communityAction())
+
+  return [community]
+}

--- a/src/about/cli.ts
+++ b/src/about/cli.ts
@@ -4,16 +4,16 @@ const communityAction = () => async () => {
   console.log([
     'Browse public Edge code on GitHub:\n',
     '  https://github.com/edge\n\n',
-    'Chat with the community on Telegram, Discord, or Reddit:\n',
+    'Chat with the community on Discord, Telegram, or Reddit:\n',
+    '  https://discord.gg/edge-network\n',
     '  https://t.me/edgenetwork\n',
-    '  https://discord.gg/3sEvuYJ\n',
     '  https://reddit.com/r/edgenetwork\n\n',
     'Follow Edge on Twitter or Facebook:\n',
     '  https://twitter.com/edgenetwork\n',
     '  https://www.facebook.com/edgenetworktech\n\n',
     'Keep up with Edge on Medium or sign up to the mailing list:\n',
-    '  https://medium.com/dadi\n',
-    '  https://edge.network/en/'
+    '  https://edge.medium.com\n',
+    '  https://edge.press'
   ].join(''))
 }
 

--- a/src/about/cli.ts
+++ b/src/about/cli.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander'
 
 const communityAction = () => async () => {
   console.log([
-    '\n',
     'Browse public Edge code on GitHub:\n',
     '  https://github.com/edge\n\n',
     'Chat with the community on Telegram, Discord, or Reddit:\n',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import * as aboutCLI from './about/cli'
 import * as deviceCLI from './device/cli'
 import * as stakeCLI from './stake/cli'
 import * as transactionCLI from './transaction/cli'
@@ -21,6 +22,7 @@ const addProviders = (ctx: Pick<Context, 'parent' | 'network'>): Context => {
 
 const main = (argv: string[], network: Network): void => {
   const parent = createCLI(network)
+  aboutCLI.commands().forEach(cmd => parent.addCommand(cmd))
   const ctx = addProviders({ parent, network })
 
   if (network.flags.onboarding) parent.addCommand(deviceCLI.withContext(ctx))


### PR DESCRIPTION
Nobody asked for it, but I thought it'd be a fun ten-minute job to round off a productive day.

```
cli % ./bin/edgetest community
Browse public Edge code on GitHub:
  https://github.com/edge

Chat with the community on Telegram, Discord, or Reddit:
  https://t.me/edgenetwork
  https://discord.gg/3sEvuYJ
  https://reddit.com/r/edgenetwork

Follow Edge on Twitter or Facebook:
  https://twitter.com/edgenetwork
  https://www.facebook.com/edgenetworktech

Keep up with Edge on Medium or sign up to the mailing list:
  https://medium.com/dadi
  https://edge.network/en/
```

Thinking an `edge support` command wouldn't hurt either.

Language/brand feedback welcomed.