### PR TITLE
feat: change container discovery behaviour

### DIFF
--- a/src/device/cli.ts
+++ b/src/device/cli.ts
@@ -324,7 +324,7 @@ const startAction = ({ device, logger, ...ctx }: CommandContext) => async () => 
   const latestImage = await waitForImage(docker, node.image)
   log.debug('latest image', { latestImage })
 
-  const containerOptions = createContainerOptions(node.image, env)
+  const containerOptions = createContainerOptions(node.image, node.containerName, env)
   log.debug('creating container', { containerOptions })
   const container = await docker.createContainer(containerOptions)
   log.debug('starting container')
@@ -416,7 +416,7 @@ const updateAction = ({ device, logger }: CommandContext) => async () => {
   console.log(`Restarting ${node.name}...`)
   await container.stop()
 
-  const containerOptions = createContainerOptions(node.image, containerInspect?.Config.Env)
+  const containerOptions = createContainerOptions(node.image, node.containerName, containerInspect?.Config.Env)
   log.debug('creating container', { containerOptions })
   container = await docker.createContainer(containerOptions)
   log.debug('starting container')
@@ -430,8 +430,9 @@ const updateAction = ({ device, logger }: CommandContext) => async () => {
 
 const updateHelp = '\nUpdate the node, if an update is available.'
 
-const createContainerOptions = (image: string, env: string[] | undefined): ContainerCreateOptions => ({
+const createContainerOptions = (image: string, name: string, env: string[] | undefined): ContainerCreateOptions => ({
   Image: image,
+  name,
   AttachStdin: false,
   AttachStdout: false,
   AttachStderr: false,

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -77,18 +77,27 @@ const device = ({ logger, wallet, xe, network, parent }: Context, name = 'device
     const tag = await currentTag()
     const image = network.registry.imageName(stake.type, arch()) + ':' + tag
     const name = toUpperCaseFirst(stake.type)
+    const containerName = `edge_${stake.type}_${address.slice(3, 9)}`
 
     log.debug('found node', { image, name, stake })
 
     const container = async () => {
-      log.debug('finding container', { name, image })
-      const info = (await docker().listContainers()).find(c => c.Image === image)
-      if (info !== undefined) log.debug('found container', { id: info.Id })
+      log.debug('finding container', { containerName })
+      const remoteName = `/${containerName}`
+      const info = (await docker().listContainers()).find(c => c.Names.includes(remoteName))
+      if (info !== undefined) {
+        log.debug('found container', {
+          id: info.Id,
+          image: info.Image,
+          imageID: info.ImageID
+        })
+      }
       return info
     }
 
     return {
       container,
+      containerName,
       image,
       name,
       stake


### PR DESCRIPTION
this previously worked by matching on image name, but this is not robust especially when using different :version tags. a singular container name ensures more reliable matching