### PR TITLE
Testnet v1.4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 /out
 .DS_Store
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chalk": "^4.1.2",
         "commander": "^8.1.0",
         "dockerode": "^3.3.1",
+        "dotenv": "^10.0.0",
         "semver": "^7.3.5",
         "superagent": "^6.1.0",
         "tar-stream": "^2.2.0"
@@ -1142,6 +1143,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/elliptic": {
@@ -4148,6 +4157,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "elliptic": {
       "version": "6.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chalk": "^4.1.2",
     "commander": "^8.1.0",
     "dockerode": "^3.3.1",
+    "dotenv": "^10.0.0",
     "semver": "^7.3.5",
     "superagent": "^6.1.0",
     "tar-stream": "^2.2.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 
+import dotenv from 'dotenv'
+
+dotenv.config()
+
 export default {
   blockchain: {
     defaultTimeout: parseInt(process.env.BLOCKCHAIN_TIMEOUT || '10') * 1000

--- a/src/device/cli.ts
+++ b/src/device/cli.ts
@@ -320,18 +320,15 @@ const startAction = ({ device, logger, ...ctx }: CommandContext) => async () => 
     return
   }
 
-  console.log(`Checking for latest ${node.name} version...`)
+  console.log(`Checking ${node.name} version...`)
   const authconfig = getRegistryAuthOptions(ctx.cmd)
   const { target } = await getTargetOption(ctx, ctx.cmd, node.stake.type)
   log.debug('got target version', { target })
   const targetImage = `${node.image}:${target}`
 
-  console.log(`Downloading ${node.name} v${target}...`)
+  console.log(`Updating ${node.name} v${target}...`)
   if (authconfig !== undefined) await docker.pull(targetImage, { authconfig })
   else await docker.pull(targetImage)
-  log.debug('pulled latest image', { image: targetImage })
-  log.debug('pulled latest image', { image: node.image })
-
   const latestImage = await waitForImage(docker, targetImage)
   log.debug('latest image', { latestImage })
 
@@ -392,6 +389,7 @@ const updateAction = ({ device, logger, ...ctx }: CommandContext) => async () =>
   const docker = userDevice.docker()
   const node = await userDevice.node()
 
+  console.log(`Checking ${node.name} version...`)
   const { target } = await getTargetOption(ctx, ctx.cmd, node.stake.type)
   log.debug('got target version', { target })
   const targetImage = `${node.image}:${target}`
@@ -404,7 +402,6 @@ const updateAction = ({ device, logger, ...ctx }: CommandContext) => async () =>
   if (containerInspect !== undefined) {
     // get running container image to compare
     currentImage = await docker.getImage(containerInspect.Image).inspect()
-    log.debug('current image', { currentImage })
   }
   else {
     try {
@@ -417,21 +414,19 @@ const updateAction = ({ device, logger, ...ctx }: CommandContext) => async () =>
   }
   if (currentImage !== undefined) log.debug('current image', { currentImage })
 
-  console.log(`Checking for/downloading ${node.name} update...`)
+  console.log(`Updating ${node.name} v${target}...`)
   const authconfig = getRegistryAuthOptions(ctx.cmd)
-
   if (authconfig !== undefined) await docker.pull(targetImage, { authconfig })
   else await docker.pull(targetImage)
-  log.debug('pulled latest image', { image: targetImage })
   const latestImage = await waitForImage(docker, targetImage)
   log.debug('latest image', { latestImage })
 
   console.log()
   if (latestImage.Id === currentImage?.Id) {
-    console.log(`${node.name} is up to date.`)
+    console.log(`${node.name} is up to date`)
     return
   }
-  console.log(`${node.name} has been updated.`)
+  console.log(`${node.name} has been updated`)
 
   if (container === undefined) return
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,9 @@ export type Network = {
   registry: {
     imageName: (app: string, arch: string) => string
   }
+  stargate: {
+    serviceURL: (app: string) => string
+  }
   wallet: {
     defaultFile: string
   }

--- a/src/main-mainnet.ts
+++ b/src/main-mainnet.ts
@@ -28,6 +28,9 @@ main(process.argv, {
   registry: {
     imageName: (app, arch) => `${config.docker.edgeRegistry.address}/${app}/mainnet-${arch}`
   },
+  stargate: {
+    serviceURL: app => `https://stargate.edge.network/services/${app}`
+  },
   wallet: {
     defaultFile: `${homedir}${sep}.edge${sep}wallet${sep}mainnet.json`
   }

--- a/src/main-testnet.ts
+++ b/src/main-testnet.ts
@@ -30,6 +30,9 @@ main(process.argv, {
   registry: {
     imageName: (app, arch) => `${config.docker.edgeRegistry.address}/${app}/testnet-${arch}`
   },
+  stargate: {
+    serviceURL: app => `https://stargate.test.network/services/${app}`
+  },
   wallet: {
     defaultFile: `${homedir}${sep}.edge${sep}wallet${sep}testnet.json`
   }

--- a/src/stargate/index.ts
+++ b/src/stargate/index.ts
@@ -1,0 +1,8 @@
+import { Network } from '../'
+import superagent from 'superagent'
+
+export const getServiceVersion = async (network: Network, name: string): Promise<string> => {
+  const res = await superagent.get(network.stargate.serviceURL(name))
+  const data = res.body as { name: string, version: string }
+  return data.version
+}


### PR DESCRIPTION
Documentary PR for reference, not awaiting review.

In this update:

- Fixed some issues with the `device update --target` option
- Integrated Stargate service versioning #83 
- Added `dotenv` so some static configuration (e.g. registry auth) can now be stored in root path
