### PR TITLE
Improved progress indicator

### DIFF
--- a/src/device/data.ts
+++ b/src/device/data.ts
@@ -37,15 +37,6 @@ const createTransferContainer = (docker: Docker, volume: VolumeInspectInfo, path
 
 export const keys: (keyof Device)[] = ['address', 'network', 'privateKey', 'publicKey']
 
-const pullTransferContainerImage = async (docker: Docker): Promise<void> => {
-  if (await image.exists(docker, TRANSFER_CONTAINER_IMAGE)) return
-  let dots = ''
-  await image.pull(docker, TRANSFER_CONTAINER_IMAGE, undefined, () => {
-    dots += '.'
-    console.log(dots)
-  })
-}
-
 /**
  * Read device data from a volume (typically the data volume).
  */
@@ -82,7 +73,8 @@ const readDirect = async (volume: VolumeInspectInfo) => new Promise<Device>((res
  */
 const readThroughContainer = async (docker: Docker, volume: VolumeInspectInfo): Promise<Device> => {
   const path = '/data'
-  await pullTransferContainerImage(docker)
+  // eslint-disable-next-line max-len
+  if (!await image.exists(docker, TRANSFER_CONTAINER_IMAGE)) await image.pullVisible(docker, TRANSFER_CONTAINER_IMAGE, undefined)
   const container = await createTransferContainer(docker, volume, path)
 
   await container.start()
@@ -191,7 +183,8 @@ const writeDirect = async (volume: VolumeInspectInfo, device: Device) => new Pro
  */
 const writeThroughContainer = async (docker: Docker, volume: VolumeInspectInfo, device: Device): Promise<void> => {
   const path = '/data'
-  await pullTransferContainerImage(docker)
+  // eslint-disable-next-line max-len
+  if (!await image.exists(docker, TRANSFER_CONTAINER_IMAGE)) await image.pullVisible(docker, TRANSFER_CONTAINER_IMAGE, undefined)
   const container = await createTransferContainer(docker, volume, path)
 
   await container.start()

--- a/src/device/image.ts
+++ b/src/device/image.ts
@@ -1,5 +1,26 @@
+import readline from 'readline'
 import Docker, { AuthConfig } from 'dockerode'
 
+/**
+ * PullStatus
+ */
+export type PullStatus = {
+  status: string
+  id?: string
+  progress?: string
+  progressDetail?: {
+    current: number
+    total: number
+  }
+}
+
+/**
+ * Check whether an image exists in Docker.
+ *
+ * For convenience, this function has no failure case. In the event of an error (e.g. loss of connection) it simply
+ * returns false. Calling code should continue to attempt to interact with Docker, and safely handle any error arising
+ * from imperative actions.
+ */
 export const exists = async (docker: Docker, imageName: string): Promise<boolean> => {
   const img = docker.getImage(imageName)
   try {
@@ -12,15 +33,89 @@ export const exists = async (docker: Docker, imageName: string): Promise<boolean
   return true
 }
 
+/**
+ * Pull a remote image to Docker.
+ *
+ * An `onData` callback can be provided to receive updates on pull status during download.
+ */
 export const pull = async (
   docker: Docker,
   imageName: string,
   authconfig?: AuthConfig,
-  onData = () => {/*silent*/}
+  onData?: (status: PullStatus) => void
 ): Promise<void> => new Promise((resolve, reject) => {
   docker.pull(imageName, { authconfig }, (err, stream) => {
     if (err !== null) return reject(err)
-    stream.on('data', onData)
+    if (onData !== undefined) {
+      stream.on('data', (b: Buffer) => {
+        // it is possible for multiple json strings to be bundled in a single response, so we just take the latest
+        const d = b.toString().split('\n').filter(l => l).pop() as string
+        try {
+          const status = JSON.parse(d) as PullStatus
+          onData(status)
+        }
+        catch (err) {
+          console.error(err, d)
+        }
+      })
+    }
     stream.on('end', resolve)
   })
 })
+
+/**
+ * Pull a remote image to Docker with standard display of pull status.
+ *
+ * If `keepText` is false (the default), this function will flash pull status text to stdout to indicate progress,
+ * self-cleaning after each update.
+ *
+ * If `keepText` is true, each pull status update is written to a new line without clearing the previous update.
+ * This may be useful for debugging.
+ */
+export const pullVisible = async (
+  docker: Docker,
+  imageName: string,
+  authconfig?: AuthConfig,
+  keepText = false
+): Promise<void> => {
+  const ws = process.stdout
+
+  let canWrite = true
+  const buf: PullStatus[] = []
+
+  const update = (status: PullStatus) => {
+    if (keepText) {
+      if (status.progress) console.log(status.status, status.progress)
+      else console.log(status.status)
+    }
+    else {
+      readline.clearLine(ws, -1, () => {
+        readline.cursorTo(ws, 0, undefined, () => {
+          if (status.progress) canWrite = ws.write(`${status.status} ${status.progress}`)
+          else canWrite = ws.write(status.status)
+        })
+      })
+    }
+  }
+
+  const onDrain = () => {
+    const status = buf.shift()
+    if (status === undefined) return
+    canWrite = true
+    update(status)
+  }
+
+  if (!keepText) ws.on('drain', onDrain)
+
+  await pull(docker, imageName, authconfig, status => {
+    if (canWrite) update(status)
+    else buf.push(status)
+  })
+
+  if (!keepText) {
+    ws.off('drain', onDrain)
+    readline.clearLine(ws, -1, () => {
+      readline.cursorTo(ws, 0, undefined)
+    })
+  }
+}


### PR DESCRIPTION
This PR introduces a 'clean' progress indicator for Docker pulls, providing better insight into Docker engine activity.

It also provides partial support for `--debug` to enable preservation of stdout messages. (At the moment this does not work for pulling alpine images for data transfer, but I don't consider this a priority at the moment as it requires a lot of changes for a one-off download.)