### PR TITLE
v1.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.7.5",
+      "version": "1.7.6",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/src/device/cli.ts
+++ b/src/device/cli.ts
@@ -558,6 +558,9 @@ const createContainerOptions = (
     Math.random().toString(16).substring(2, 8)
   ].filter(Boolean).join('-')
 
+  let volumeName = config.docker.dataVolume
+  if (prefix) volumeName = `${volumeName}-${prefix}`
+
   const opts: ContainerCreateOptions = {
     Image: `${node.image}:${tag}`,
     name: containerName,
@@ -571,7 +574,7 @@ const createContainerOptions = (
     HostConfig: {
       Binds: [
         '/var/run/docker.sock:/var/run/docker.sock',
-        `${config.docker.dataVolume}:/data`
+        `${volumeName}:/data`
       ],
       RestartPolicy: { Name: 'unless-stopped' }
     }


### PR DESCRIPTION
This patch fixes a bug with the incorrect volume being bound when starting a prefixed node.