### PR TITLE
v1.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,8 +1155,9 @@
       "optional": true
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -4359,8 +4360,9 @@
       "optional": true
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/cli/docker.ts
+++ b/src/cli/docker.ts
@@ -14,6 +14,12 @@ export type EnvOption = {
   env: string[]
 }
 
+/** Docker environment file options. */
+export type EnvFileOption = {
+  /** Env variables file to use for a Docker container. */
+  envFile: string
+}
+
 /** Docker networking options. */
 export type NetworksOption = {
   /** Docker networks for a container to join. */
@@ -46,6 +52,11 @@ export const configureConnection = (cmd: Command): void => {
 /** Configure a command with Docker environment options. */
 export const configureEnv = (cmd: Command): void => {
   cmd.option('-e, --env <var...>', 'set environment variable(s) for node')
+}
+
+/** Configure a command with a Docker env file. */
+export const configureEnvFile = (cmd: Command): void => {
+  cmd.option('--env-file <path>', 'set environment variables file for node')
 }
 
 /** Configure a command with Docker networking options. */
@@ -92,6 +103,12 @@ export const readEnv = (cmd: Command): EnvOption => {
   return {
     env: opts.env !== undefined ? opts.env : []
   }
+}
+
+/** Read Docker environment file options from a command. */
+export const readEnvFile = (cmd: Command): EnvFileOption => {
+  const opts = cmd.opts()
+  return { envFile: opts.envFile }
 }
 
 /** Read Docker network options from a command. */

--- a/src/device/cli/index.ts
+++ b/src/device/cli/index.ts
@@ -7,7 +7,9 @@ import { Command } from 'commander'
 import { Context } from '../../main'
 import { command as add } from './add'
 import config from '../../config'
+import dotenv from 'dotenv'
 import { command as info } from './info'
+import { readFileSync } from 'fs'
 import { command as remove } from './remove'
 import { command as restart } from './restart'
 import { command as start } from './start'
@@ -29,6 +31,7 @@ export const createContainerOptions = (
   node: NodeInfo,
   tag: string,
   env: string[] | undefined,
+  envFile?: string | undefined,
   prefix?: string | undefined,
   networks?: string[]
 ): ContainerCreateOptions => {
@@ -38,6 +41,16 @@ export const createContainerOptions = (
     prefix,
     Math.random().toString(16).substring(2, 8)
   ].filter(Boolean).join('-')
+
+  if (envFile) {
+    const oldEnv = env !== undefined ? env : []
+    env = []
+    const fileEnv = dotenv.parse(readFileSync(envFile))
+    for (const key of Object.keys(fileEnv)) {
+      env.push(`${key}=${fileEnv[key]}`)
+    }
+    for (const e of oldEnv) env.push(e)
+  }
 
   let volumeName = config.docker.dataVolume
   if (prefix) volumeName = `${volumeName}-${prefix}`

--- a/src/device/cli/start.ts
+++ b/src/device/cli/start.ts
@@ -69,8 +69,6 @@ export const command = (ctx: Context): Command => {
   return cmd
 }
 
-/* eslint-disable max-len */
 const help = (network: Network) => `
 Start the node. Your device must be added to the network first. Run '${network.appName} device add --help' for more information.
 `
-/* eslint-enable max-len */

--- a/src/device/cli/start.ts
+++ b/src/device/cli/start.ts
@@ -21,6 +21,7 @@ import { Context, Network } from '../../main'
 export const action = (ctx: Context) => async (): Promise<void> => {
   const opts = {
     ...cli.docker.readEnv(ctx.cmd),
+    ...cli.docker.readEnvFile(ctx.cmd),
     ...cli.docker.readNetworks(ctx.cmd),
     ...cli.docker.readPrefix(ctx.cmd)
   }
@@ -47,7 +48,7 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   if (authconfig !== undefined) await image.pullVisible(docker, targetImage, authconfig, debug)
   else await image.pullVisible(docker, targetImage, authconfig, debug)
 
-  const containerOptions = createContainerOptions(node, target, opts.env, opts.prefix, opts.network)
+  const containerOptions = createContainerOptions(node, target, opts.env, opts.envFile, opts.prefix, opts.network)
   log.debug('creating container', { containerOptions })
   const container = await docker.createContainer(containerOptions)
   log.debug('starting container')
@@ -62,6 +63,7 @@ export const command = (ctx: Context): Command => {
   const cmd = new Command('start').description('start node').addHelpText('after', help(ctx.network))
   cli.docker.configureAuth(cmd)
   cli.docker.configureEnv(cmd)
+  cli.docker.configureEnvFile(cmd)
   cli.docker.configureNetworks(cmd)
   cli.docker.configurePrefix(cmd)
   cli.docker.configureTarget(cmd)

--- a/src/device/data.ts
+++ b/src/device/data.ts
@@ -73,7 +73,6 @@ const readDirect = async (volume: VolumeInspectInfo) => new Promise<Device>((res
  */
 const readThroughContainer = async (docker: Docker, volume: VolumeInspectInfo): Promise<Device> => {
   const path = '/data'
-  // eslint-disable-next-line max-len
   if (!await image.exists(docker, TRANSFER_CONTAINER_IMAGE)) await image.pullVisible(docker, TRANSFER_CONTAINER_IMAGE, undefined)
   const container = await createTransferContainer(docker, volume, path)
   await container.start()
@@ -184,7 +183,6 @@ const writeDirect = async (volume: VolumeInspectInfo, device: Device) => new Pro
  */
 const writeThroughContainer = async (docker: Docker, volume: VolumeInspectInfo, device: Device): Promise<void> => {
   const path = '/data'
-  // eslint-disable-next-line max-len
   if (!await image.exists(docker, TRANSFER_CONTAINER_IMAGE)) await image.pullVisible(docker, TRANSFER_CONTAINER_IMAGE, undefined)
   const container = await createTransferContainer(docker, volume, path)
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,7 +10,7 @@ export const formatTime = (t: number): string => {
   const [yyyy, mm, dd, h, m, s] = [
     d.getUTCFullYear(),
     (1 + d.getUTCMonth()).toString().padStart(2, '0'),
-    (1 + d.getUTCDate()).toString().padStart(2, '0'),
+    d.getUTCDate().toString().padStart(2, '0'),
     d.getUTCHours().toString().padStart(2, '0'),
     d.getUTCMinutes().toString().padStart(2, '0'),
     d.getUTCSeconds().toString().padStart(2, '0')

--- a/src/main-mainnet.ts
+++ b/src/main-mainnet.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/main-testnet.ts
+++ b/src/main-testnet.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import xeClient, { XEClient } from './api/xe'
  */
 export type Context = {
   cmd: Command
-    /**
+  /**
    * Provider for a device object.
    *
    * `prefix` determines which device/node should be accessed; if undefined, it will default to an un-prefixed

--- a/src/stake/cli/create.ts
+++ b/src/stake/cli/create.ts
@@ -41,7 +41,6 @@ export const action = (ctx: Context) => async (nodeType: string): Promise<void> 
         nodeType === 'stargate' ? vars.stargate_stake_amount : 0
 
   const resultBalance = availableBalance - amount
-  // eslint-disable-next-line max-len
   if (resultBalance < 0) throw new Error(`insufficient balance to stake ${nodeType}: your wallet only contains ${formatXE(availableBalance)} (${formatXE(amount)} required)`)
 
   if (!opts.yes) {

--- a/src/stake/cli/index.ts
+++ b/src/stake/cli/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/stake/index.ts
+++ b/src/stake/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/transaction/cli/send.ts
+++ b/src/transaction/cli/send.ts
@@ -32,7 +32,6 @@ export const action = (ctx: Context) => async (amountInput: string, recipient: s
   const availableBalance = onChainWallet.balance - pendingTxsAmount
 
   const resultBalance = availableBalance - amount
-  // eslint-disable-next-line max-len
   if (resultBalance < 0) throw new Error(`insufficient balance: your wallet only contains ${formatXE(availableBalance)}`)
 
   if (!opts.yes) {

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/update/cli/index.ts
+++ b/src/update/cli/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 

--- a/src/wallet/cli/create.ts
+++ b/src/wallet/cli/create.ts
@@ -96,7 +96,6 @@ export const command = (ctx: Context): Command => {
   return cmd
 }
 
-/* eslint-disable max-len */
 const help = repl.help(`
 This command will create a new wallet.
 
@@ -106,4 +105,3 @@ The passphrase is also required later to decrypt the wallet for certain actions,
 
 You will also be given the option to view or export the private key for the new wallet. This should be copied to a secure location and kept secret.
 `)
-/* eslint-enable max-len */

--- a/src/wallet/cli/index.ts
+++ b/src/wallet/cli/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Edge Network Technologies Limited
+// Copyright (C) 2022 Edge Network Technologies Limited
 // Use of this source code is governed by a GNU GPL-style license
 // that can be found in the LICENSE.md file. All rights reserved.
 


### PR DESCRIPTION
This update fixes a bug in date formatting and adds a new `--env-file` option to the `device start` command. This makes it simpler and more secure to run nodes (particularly Stargate and Gateway) without adding their env config to history.