### PR TITLE
v1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ const config = {
     dataVolume: process.env.DOCKER_DATA_VOLUME || 'edge-device-data',
     directReadWrite: process.env.DOCKER_DIRECT_RW === 'true',
     registry: {
-      address: 'registry.edge.network',
+      address: process.env.REGISTRY || 'registry.edge.network',
       defaultImageTag: 'latest',
       auth: {
         username: process.env.REGISTRY_USERNAME || '',

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,32 +4,37 @@
 
 import dotenv from 'dotenv'
 
-dotenv.config()
+export type Config = typeof config
+
+let envFile = '.env'
+if (process.env.ENV_FILE) envFile = process.env.ENV_FILE
+dotenv.config({ path: envFile })
 
 /**
  * Global configuration.
  * Some properties can be specified in the shell environment.
  * However, it's normally best to leave these alone unless debugging or Edge Core Team advises changes.
  */
-export default {
+const config = {
   address: {
     shortLength: 9
   },
   blockchain: {
-    defaultTimeout: parseInt(process.env.BLOCKCHAIN_TIMEOUT || '10') * 1000
+    defaultTimeout: parseInt(process.env.CLI_BLOCKCHAIN_TIMEOUT || '10') * 1000
   },
   docker: {
     dataVolume: process.env.DOCKER_DATA_VOLUME || 'edge-device-data',
     directReadWrite: process.env.DOCKER_DIRECT_RW === 'true',
-    edgeRegistry: {
+    registry: {
       address: 'registry.edge.network',
       defaultImageTag: 'latest',
       auth: {
-        username: process.env.EDGE_REGISTRY_USERNAME || '',
-        password: process.env.EDGE_REGISTRY_PASSWORD || ''
+        username: process.env.REGISTRY_USERNAME || '',
+        password: process.env.REGISTRY_PASSWORD || ''
       }
     }
   },
+  envFile,
   hash: {
     shortLength: 8
   },
@@ -38,9 +43,11 @@ export default {
     shortLength: 12
   },
   index: {
-    defaultTimeout: parseInt(process.env.INDEX_TIMEOUT || '10') * 1000
+    defaultTimeout: parseInt(process.env.CLI_INDEX_TIMEOUT || '10') * 1000
   },
   signature: {
     shortLength: 12
   }
 }
+
+export default config

--- a/src/device/cli/env.ts
+++ b/src/device/cli/env.ts
@@ -7,6 +7,7 @@ import * as repl from '../../repl'
 import { Command } from 'commander'
 import { Context } from '../../main'
 import { checkVersionHandler } from '../../update/cli'
+import config from '../../config'
 import { errorHandler } from '../../cli'
 
 /**
@@ -21,12 +22,16 @@ export const action = (ctx: Context) => async (): Promise<void> => {
 }
 
 export const command = (ctx: Context): Command => {
-  const cmd = new Command('env').description('display environment variables').addHelpText('after', help)
+  const cmd = new Command('env').description('display environment variables').addHelpText('after', help(ctx))
   cli.docker.configurePrefix(cmd)
   cmd.action(errorHandler(ctx, checkVersionHandler(ctx, action({ ...ctx, cmd }))))
   return cmd
 }
 
-const help = repl.help(`
-This command displays environment variables passed from your host machine to the device. It may be useful for debugging.
+const help = ({ network }: Context) => repl.help(`
+This command displays environment variables passed implicitly from your host machine to the device when using '${network.appName} device start'.
+
+Environment variables are managed in ${config.envFile}. To change the location of your environment file, prefix your CLI usage with 'ENV_FILE=<path>'.
+
+You can also override the file path by using '${network.appName} device start --env-file=<path>'.
 `)

--- a/src/device/cli/env.ts
+++ b/src/device/cli/env.ts
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Edge Network Technologies Limited
+// Use of this source code is governed by a GNU GPL-style license
+// that can be found in the LICENSE.md file. All rights reserved.
+
+import * as cli from '../../cli'
+import * as repl from '../../repl'
+import { Command } from 'commander'
+import { Context } from '../../main'
+import { checkVersionHandler } from '../../update/cli'
+import { errorHandler } from '../../cli'
+
+/**
+ * Display device information.
+ */
+export const action = (ctx: Context) => async (): Promise<void> => {
+  const opts = {
+    ...cli.docker.readAllEnv(ctx.parent)
+  }
+
+  repl.raw(opts.env.join('\n'))
+}
+
+export const command = (ctx: Context): Command => {
+  const cmd = new Command('env').description('display environment variables').addHelpText('after', help)
+  cli.docker.configurePrefix(cmd)
+  cmd.action(errorHandler(ctx, checkVersionHandler(ctx, action({ ...ctx, cmd }))))
+  return cmd
+}
+
+const help = repl.help(`
+This command displays environment variables passed from your host machine to the device. It may be useful for debugging.
+`)

--- a/src/device/cli/index.ts
+++ b/src/device/cli/index.ts
@@ -7,9 +7,8 @@ import { Command } from 'commander'
 import { Context } from '../../main'
 import { command as add } from './add'
 import config from '../../config'
-import dotenv from 'dotenv'
+import { command as env } from './env'
 import { command as info } from './info'
-import { readFileSync } from 'fs'
 import { command as remove } from './remove'
 import { command as restart } from './restart'
 import { command as start } from './start'
@@ -31,7 +30,6 @@ export const createContainerOptions = (
   node: NodeInfo,
   tag: string,
   env: string[] | undefined,
-  envFile?: string | undefined,
   prefix?: string | undefined,
   networks?: string[]
 ): ContainerCreateOptions => {
@@ -41,16 +39,6 @@ export const createContainerOptions = (
     prefix,
     Math.random().toString(16).substring(2, 8)
   ].filter(Boolean).join('-')
-
-  if (envFile) {
-    const oldEnv = env !== undefined ? env : []
-    env = []
-    const fileEnv = dotenv.parse(readFileSync(envFile))
-    for (const key of Object.keys(fileEnv)) {
-      env.push(`${key}=${fileEnv[key]}`)
-    }
-    for (const e of oldEnv) env.push(e)
-  }
 
   let volumeName = config.docker.dataVolume
   if (prefix) volumeName = `${volumeName}-${prefix}`
@@ -98,6 +86,7 @@ export const createContainerOptions = (
 export const command = (ctx: Context): Command => {
   const cmd = new Command('device').description('manage device')
   cmd.addCommand(add(ctx))
+  cmd.addCommand(env(ctx))
   cmd.addCommand(info(ctx))
   cmd.addCommand(remove(ctx))
   cmd.addCommand(restart(ctx))

--- a/src/device/cli/remove.ts
+++ b/src/device/cli/remove.ts
@@ -104,7 +104,10 @@ export const action = (ctx: Context) => async (): Promise<void> => {
 }
 
 export const command = (ctx: Context): Command => {
-  const cmd = new Command('remove').description('remove this device from the network').addHelpText('after', help)
+  const cmd = new Command('remove')
+    .alias('rm')
+    .description('remove this device from the network')
+    .addHelpText('after', help)
   cli.docker.configurePrefix(cmd)
   cli.yes.configure(cmd)
   cmd.action(errorHandler(ctx, checkVersionHandler(ctx, action({ ...ctx, cmd }))))

--- a/src/device/cli/start.ts
+++ b/src/device/cli/start.ts
@@ -45,8 +45,7 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   repl.echo(`Updating ${node.name} v${target}...`)
   const authconfig = cli.docker.readAuth(ctx.cmd)
   const { debug } = cli.debug.read(ctx.parent)
-  if (authconfig !== undefined) await image.pullVisible(docker, targetImage, authconfig, debug)
-  else await image.pullVisible(docker, targetImage, authconfig, debug)
+  await image.pullVisible(docker, targetImage, authconfig, debug)
 
   const containerOptions = createContainerOptions(node, target, opts.env, opts.envFile, opts.prefix, opts.network)
   log.debug('creating container', { containerOptions })

--- a/src/device/cli/start.ts
+++ b/src/device/cli/start.ts
@@ -20,8 +20,7 @@ import { Context, Network } from '../../main'
  */
 export const action = (ctx: Context) => async (): Promise<void> => {
   const opts = {
-    ...cli.docker.readEnv(ctx.cmd),
-    ...cli.docker.readEnvFile(ctx.cmd),
+    ...cli.docker.readAllEnv(ctx.cmd),
     ...cli.docker.readNetworks(ctx.cmd),
     ...cli.docker.readPrefix(ctx.cmd)
   }
@@ -47,7 +46,7 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   const { debug } = cli.debug.read(ctx.parent)
   await image.pullVisible(docker, targetImage, authconfig, debug)
 
-  const containerOptions = createContainerOptions(node, target, opts.env, opts.envFile, opts.prefix, opts.network)
+  const containerOptions = createContainerOptions(node, target, opts.env, opts.prefix, opts.network)
   log.debug('creating container', { containerOptions })
   const container = await docker.createContainer(containerOptions)
   log.debug('starting container')

--- a/src/device/cli/update.ts
+++ b/src/device/cli/update.ts
@@ -55,8 +55,7 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   repl.echo(`Updating ${node.name} v${target}...`)
   const { debug } = cli.debug.read(ctx.parent)
   const authconfig = cli.docker.readAuth(ctx.cmd)
-  if (authconfig !== undefined) await image.pullVisible(docker, targetImage, authconfig, debug)
-  else await image.pullVisible(docker, targetImage, authconfig, debug)
+  await image.pullVisible(docker, targetImage, authconfig, debug)
 
   const latestImage = await docker.getImage(targetImage).inspect()
   if (latestImage.Id === currentImage?.Id) {

--- a/src/main-mainnet.ts
+++ b/src/main-mainnet.ts
@@ -31,7 +31,7 @@ main(process.argv, {
     host: 'https://index.xe.network'
   },
   registry: {
-    imageName: (app, arch) => `${config.docker.edgeRegistry.address}/${app}/mainnet-${arch}`
+    imageName: (app, arch) => `${config.docker.registry.address}/${app}/mainnet-${arch}`
   },
   stargate: {
     host: 'https://stargate.edge.network'

--- a/src/main-testnet.ts
+++ b/src/main-testnet.ts
@@ -31,7 +31,7 @@ main(process.argv, {
     host: 'https://index.test.network'
   },
   registry: {
-    imageName: (app, arch) => `${config.docker.edgeRegistry.address}/${app}/testnet-${arch}`
+    imageName: (app, arch) => `${config.docker.registry.address}/${app}/testnet-${arch}`
   },
   stargate: {
     host: 'https://stargate.test.network'


### PR DESCRIPTION
This update adds some quality-of-life tweaks:

- Adds a `device rm` alias for `device remove` to mitigate 'unknown command' errors
- Unifies usage of env files (typically `.env`) across CLI and device apps
- Adds a `device env` command to help illustrate & debug device environment variables