### PR TITLE
v1.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@edge/cli",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edge/index-utils": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edge/cli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Command line interface for the Edge network",
   "private": true,
   "author": "Edge Network <core@edge.network>",

--- a/src/device/cli/start.ts
+++ b/src/device/cli/start.ts
@@ -21,6 +21,7 @@ import { Context, Network } from '../../main'
 export const action = (ctx: Context) => async (): Promise<void> => {
   const opts = {
     ...cli.docker.readAllEnv(ctx.cmd),
+    ...cli.docker.readAllExtraHosts(ctx.cmd, ctx.network),
     ...cli.docker.readNetworks(ctx.cmd),
     ...cli.docker.readPrefix(ctx.cmd)
   }
@@ -46,7 +47,7 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   const { debug } = cli.debug.read(ctx.parent)
   await image.pullVisible(docker, targetImage, authconfig, debug)
 
-  const containerOptions = createContainerOptions(node, target, opts.env, opts.prefix, opts.network)
+  const containerOptions = createContainerOptions(node, target, opts)
   log.debug('creating container', { containerOptions })
   const container = await docker.createContainer(containerOptions)
   log.debug('starting container')
@@ -62,8 +63,11 @@ export const command = (ctx: Context): Command => {
   cli.docker.configureAuth(cmd)
   cli.docker.configureEnv(cmd)
   cli.docker.configureEnvFile(cmd)
+  cli.docker.configureExtraHosts(cmd)
+  cli.docker.configureGateway(cmd)
   cli.docker.configureNetworks(cmd)
   cli.docker.configurePrefix(cmd)
+  cli.docker.configureStargate(cmd)
   cli.docker.configureTarget(cmd)
   cmd.action(errorHandler(ctx, checkVersionHandler(ctx, action({ ...ctx, cmd }))))
   return cmd

--- a/src/device/cli/update.ts
+++ b/src/device/cli/update.ts
@@ -73,7 +73,10 @@ export const action = (ctx: Context) => async (): Promise<void> => {
   log.debug('removing container', { id: containerInspect?.Id })
   await container.remove()
 
-  const containerOptions = createContainerOptions(node, target, containerInspect?.Config.Env)
+  const containerOptions = createContainerOptions(node, target, {
+    env: containerInspect?.Config.Env || [],
+    extraHosts: containerInspect?.HostConfig.ExtraHosts || []
+  })
   if (containerInspect && Object.keys(containerInspect.NetworkSettings.Networks).length > 0) {
     const endpoints: EndpointsConfig = {}
     Object.keys(containerInspect.NetworkSettings.Networks).forEach(n => {

--- a/src/main-mainnet.ts
+++ b/src/main-mainnet.ts
@@ -27,6 +27,9 @@ main(process.argv, {
   flags: {
     onboarding: true
   },
+  gateway: {
+    host: 'gateway.edge.network'
+  },
   index: {
     host: 'https://index.xe.network'
   },
@@ -34,7 +37,8 @@ main(process.argv, {
     imageName: (app, arch) => `${config.docker.registry.address}/${app}/mainnet-${arch}`
   },
   stargate: {
-    host: 'https://stargate.edge.network'
+    host: 'stargate.edge.network',
+    url: 'https://stargate.edge.network'
   },
   wallet: {
     defaultFile: `${homedir}${sep}.edge${sep}wallet${sep}mainnet.json`

--- a/src/main-testnet.ts
+++ b/src/main-testnet.ts
@@ -27,6 +27,9 @@ main(process.argv, {
   flags: {
     onboarding: true
   },
+  gateway: {
+    host: 'gateway.test.network'
+  },
   index: {
     host: 'https://index.test.network'
   },
@@ -34,7 +37,8 @@ main(process.argv, {
     imageName: (app, arch) => `${config.docker.registry.address}/${app}/testnet-${arch}`
   },
   stargate: {
-    host: 'https://stargate.test.network'
+    host: 'stargate.test.network',
+    url: 'https://stargate.test.network'
   },
   wallet: {
     defaultFile: `${homedir}${sep}.edge${sep}wallet${sep}testnet.json`

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,9 @@ export type Network = {
     latestVersionURL: (os: string, arch: string) => string
   }
   flags: Record<string, boolean>
+  gateway: {
+    host: string
+  }
   index: {
     host: string
   }
@@ -68,7 +71,8 @@ export type Network = {
     imageName: (app: string, arch: string) => string
   }
   stargate: {
-    host: sg.Host
+    host: string
+    url: sg.Host
   }
   wallet: {
     defaultFile: string


### PR DESCRIPTION
This patch adds the ability to override hosts (in the DNS sense) within a node container, allowing for example a particular Gateway to be specified when starting a Host.